### PR TITLE
Prevent crash when network is down

### DIFF
--- a/RNBranch/RNBranch/RNBranch.m
+++ b/RNBranch/RNBranch/RNBranch.m
@@ -52,7 +52,15 @@ RCT_EXPORT_MODULE();
 }
 
 - (void) onInitSessionFinished:(NSNotification*) notification {
-  [self.bridge.eventDispatcher sendDeviceEventWithName:@"RNBranch.initSessionFinished" body:[notification object]];
+    id notificationObject = notification.object;
+
+    // If there is an error, send back along the localized description string
+    // Raw object may contain objects which cannot be converted to JS objects
+    if (notificationObject[@"error"] != [NSNull null]) {
+        notificationObject = [notificationObject[@"error"] localizedDescription];
+    }
+
+    [self.bridge.eventDispatcher sendAppEventWithName:@"RNBranch.initSessionFinished" body:notificationObject];
 }
 
 


### PR DESCRIPTION
close #7 

Red screen error when notification object contains an error object from a failed request. I was able to 100% reproduce the issue by using LittleSnitch to block outgoing network traffic for my app on the simulator.

The was causing a crash of the app in production with an error message that didn’t really give much detail. Fortunately I was able to get a user who had the issue to tell me it happened when his network connection was spotty. Used LittleSnitch and put a breakpoint in the `RCTJSExecutor.m` `_executeJSCall` method. Continued until I saw the log of the error and then backtracked to the event previous and it was the init call for RNBranch. Added in the checks in the PR and things are good now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/branchmetrics/react-native-deep-linking-sdk/8)
<!-- Reviewable:end -->
