### PR TITLE
added public method: onNewReferringParams

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,10 @@ class Branch {
     rnBranch.getFirstReferringParams(callback);
   };
 
+  onNewReferringParams = (callback) => {
+    nativeEventEmitter.addListener('RNBranch.initSessionFinished', callback);
+  };
+
   setIdentity = (identity) => {
     rnBranch.setIdentity(identity);
   };


### PR DESCRIPTION
I had some issues with getInitSessionResultPatiently never receiving any parameters when clicking on a deeplink. Because of those, I decided to create a function to allow attaching listeners directly to the RNBranch.initSessionFinished event 